### PR TITLE
set is_in_extra to false for WASB host field

### DIFF
--- a/connections/dev/azure/wasb_managed_identity.yml
+++ b/connections/dev/azure/wasb_managed_identity.yml
@@ -9,6 +9,6 @@ method_name: Managed Identity (requires provider v8.2+)
     type: str
     is_required: true
     is_secret: false
-    is_in_extra: true
+    is_in_extra: false
     description: The account URL for Azure Blob Storage
     example: storageaccount.blob.core.windows.net


### PR DESCRIPTION
the WASB connection's `host` field is not read from extras. i believe this misconfig is causing weird behavior where the WASB connection set through Astro is not working properly, need to test it out. it might be even simpler to replace this `host` argument with `login` (due to [this logic](https://github.com/apache/airflow/blob/4dbc17e0b3bd9952118db288b2a8058b12e7e2f7/airflow/providers/microsoft/azure/hooks/wasb.py#L169)), but will do that in a followup if this works.