### PR TITLE
switch wasb connection to use login rather than host

### DIFF
--- a/connections/dev/azure/wasb_managed_identity.yml
+++ b/connections/dev/azure/wasb_managed_identity.yml
@@ -4,11 +4,11 @@ inherit_from: azure_managed_identity
 connection_name: WASB
 method_name: Managed Identity (requires provider v8.2+)
 +parameters:
-  - airflow_param_name: host
-    friendly_name: Blob Storage Host
+  - airflow_param_name: login
+    friendly_name: Blob Storage Account Name
     type: str
     is_required: true
     is_secret: false
     is_in_extra: false
-    description: The account URL for Azure Blob Storage
-    example: storageaccount.blob.core.windows.net
+    description: The Azure Blob Storage Account
+    example: storageaccount


### PR DESCRIPTION
using `login`, which is just the storage account name, is simpler than using `host`, which is `<storage-account>.blob.core.windows.net`