### PR TITLE
Add connection for private key content for a Snowflake connection

### DIFF
--- a/connections/dev/snowflake/private_key_content.yml
+++ b/connections/dev/snowflake/private_key_content.yml
@@ -1,0 +1,26 @@
+id: snowflake_private_key
+visible: true
+inherit_from: snowflake_base
+method_name: Private Key (Content)
++parameters:
+  # password
+  - airflow_param_name: password
+    friendly_name: Private Key Passphrase
+    type: str
+    is_required: true
+    is_secret: true
+    description: The passphrase to use for authenticating against Snowflake.
+    example: my_private_key_passphrase
+
+  # private_key_content
+  - airflow_param_name: private_key_content
+    friendly_name: Private Key Content
+    type: str
+    is_required: true
+    is_in_extra: true
+    is_secret: true
+    description: The content of the private key to use for authenticating against Snowflake.
+    example: |
+      -----BEGIN ENCRYPTED PRIVATE KEY-----
+      MIIE6T...
+      -----END ENCRYPTED PRIVATE KEY-----

--- a/connections/dev/snowflake/private_key_content.yml
+++ b/connections/dev/snowflake/private_key_content.yml
@@ -1,4 +1,4 @@
-id: snowflake_private_key
+id: snowflake_private_key_content
 visible: true
 inherit_from: snowflake_base
 method_name: Private Key (Content)

--- a/connections/dev/snowflake/private_key_path.yml
+++ b/connections/dev/snowflake/private_key_path.yml
@@ -1,7 +1,7 @@
 id: snowflake_private_key
 visible: true
 inherit_from: snowflake_base
-method_name: Private Key
+method_name: Private Key (Path)
 +parameters:
   # password
   - airflow_param_name: password

--- a/connections/dev/snowflake/private_key_path.yml
+++ b/connections/dev/snowflake/private_key_path.yml
@@ -1,4 +1,4 @@
-id: snowflake_private_key_path
+id: snowflake_private_key
 visible: true
 inherit_from: snowflake_base
 method_name: Private Key (Path)

--- a/connections/dev/snowflake/private_key_path.yml
+++ b/connections/dev/snowflake/private_key_path.yml
@@ -1,4 +1,4 @@
-id: snowflake_private_key
+id: snowflake_private_key_path
 visible: true
 inherit_from: snowflake_base
 method_name: Private Key (Path)


### PR DESCRIPTION
We currently only support private keys on Snowflake via a path. This leads to bad practices because people often store the key in Git or some other insecure location because they need to bake the key into the image. A better practice would be to support adding the key content in the Astro Connections UI.

Two questions:

1. I created a new connection type because AFAICT there's no way to specify "one of these two arguments is required" in the YAML spec. So my alternative is to create two separate connections. For this I edited the id (`snowflake_private_key` -> `snowflake_private_key_path`), but I'm not sure if this has any unintended side-effects.
2. I don't know how a multiline value for `example` is rendered, does that work?