### PR TITLE
Store AWS secret access key in password to avoid displaying it

### DIFF
--- a/connections/dev/aws/base.yml
+++ b/connections/dev/aws/base.yml
@@ -5,19 +5,19 @@ connection_name: AWS
 description: Configure a connection to AWS.
 package: apache-airflow-providers-amazon
 parameters:
-  - airflow_param_name: aws_access_key_id
+  - airflow_param_name: login
     friendly_name: Access Key ID
     description: AWS Access Key ID
     example: AKIAIOSFODNN7EXAMPLE
     type: str
-    is_in_extra: true
+    is_in_extra: false
     is_required: true
     is_secret: false
-  - airflow_param_name: aws_secret_access_key
+  - airflow_param_name: password
     friendly_name: Secret Access Key
     description: AWS Secret Access Key
     example: wJalrXUtnFEMI%2FK7MDENGbPxRfiCYEXAMPLEKEY
     type: str
-    is_in_extra: true
+    is_in_extra: false
     is_required: true
     is_secret: true


### PR DESCRIPTION
AWS connections support the configuration of secrets in two ways:

1. Via username/password (configure respectively AWS access key id/secret access key)
2. Via extras

We currently use option 2, which is not ideal because although extras are stored encrypted in the DB, they are displayed in plain text in the Airflow UI. As a result, when using Astro Connections in local development + AWS connection, developers can see the AWS secret access key in plain text. It would be better to use option 1 so that the secret access key is stored in the password field of which the value isn't visible when inspecting the connection in the Airflow UI.