### PR TITLE
Change private key content to longtext

### DIFF
--- a/connections/dev/snowflake/private_key_content.yml
+++ b/connections/dev/snowflake/private_key_content.yml
@@ -15,7 +15,7 @@ method_name: Private Key (Content)
   # private_key_content
   - airflow_param_name: private_key_content
     friendly_name: Private Key Content
-    type: str
+    type: longtext
     is_required: true
     is_in_extra: true
     is_secret: true


### PR DESCRIPTION
This changes the "Snowflake - Private Key (Content)" connection type's private key content param to use the 'longtext' data type instead of 'str' so that newlines in the private key are properly handled.