### PR TITLE
update `gcp` connection type to `google_cloud_platform`

### DIFF
--- a/connections/dev/gcp/base.yml
+++ b/connections/dev/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)

--- a/connections/prod/gcp/base.yml
+++ b/connections/prod/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)

--- a/connections/stage/gcp/base.yml
+++ b/connections/stage/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)


### PR DESCRIPTION
GCP's connection type is `google_cloud_platform` according to the airflow provider - [Reference](https://github.com/apache/airflow/blob/83316b81584c9e516a8142778fc509f19d95cc3e/airflow/providers/google/common/hooks/base_google.py#L197). This fixes the issue on Astro