### PR TITLE
update gcp connection type to google_cloud_platform

### DIFF
--- a/connections/dev/gcp/base.yml
+++ b/connections/dev/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)

--- a/connections/prod/gcp/base.yml
+++ b/connections/prod/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)

--- a/connections/stage/gcp/base.yml
+++ b/connections/stage/gcp/base.yml
@@ -1,5 +1,5 @@
 id: gcp_base
-connection_type: gcp
+connection_type: google_cloud_platform
 visible: false
 connection_name: Google Cloud Platform
 description: Configure a connection to Google Cloud Platform services (Sheets, Drive, Cloud Storage, etc.)


### PR DESCRIPTION
same as https://github.com/astronomer/airflow-connection-docs/pull/63/files, the build on that PR was failing because it's a fork and doesn't have access to the repo secrets