### PR TITLE
Fix dbt Cloud connection form

### DIFF
--- a/connections/dev/dbt_cloud/base.yml
+++ b/connections/dev/dbt_cloud/base.yml
@@ -5,26 +5,26 @@ connection_name: dbt Cloud
 description: Configure a connection to a dbt Cloud instance
 package: apache-airflow-providers-dbt-cloud
 parameters:
-  - airflow_param_name: api_token
+  - airflow_param_name: password
     friendly_name: API Token
-    description: The API token to use when authenticating to the dbt Cloud API
+    description: The API token to use when authenticating to the dbt Cloud API.
     type: str
     is_required: true
     is_secret: true
-    is_in_extra: true
-  - airflow_param_name: tenant
+    is_in_extra: false
+  - airflow_param_name: host
     friendly_name: Tenant
-    description: The Tenant name for your dbt Cloud environment. This is particularly useful when using a single-tenant dbt Cloud instance
+    description: The Tenant name for your dbt Cloud environment. This is particularly useful when using a single-tenant dbt Cloud instance.
     example: https://my-tenant.getdbt.com
     type: str
     is_required: false
     is_secret: false
-    is_in_extra: true
-  - airflow_param_name: account_id
+    is_in_extra: false
+  - airflow_param_name: login
     friendly_name: Account ID
-    description: Optional. If an Account ID is provided in the connection, you are not required to pass account_id to operators or hook methods
+    description: Optional. If an Account ID is provided in the connection, you are not required to pass account_id to operators or hook methods.
     example: 12345
     type: str
     is_required: false
     is_secret: false
-    is_in_extra: true
+    is_in_extra: false


### PR DESCRIPTION
The [connection params for the dbt Cloud connection](https://github.com/apache/airflow/blob/defe4590e9c94a9b5157143d618a143cb30ade78/airflow/providers/dbt/cloud/hooks/dbt.py#L186) are mapped to base Airflow Connection parameters rather than custom extras.

The impetus for this change is related to an Airflow Slack convo I'm in: https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1715459224449549?thread_ts=1715203729.501869&cid=CCQ7EGB1P.