### PR TITLE
Add port to MS SQL configuration

### DIFF
--- a/connections/dev/mssql/base.yml
+++ b/connections/dev/mssql/base.yml
@@ -26,6 +26,13 @@ parameters:
     type: str
     is_required: true
     is_secret: true
+  - airflow_param_name: port
+    friendly_name: Port
+    description: The port number of the database server
+    example: 1433
+    type: int
+    is_required: true
+    is_secret: false
   - airflow_param_name: schema
     friendly_name: Schema
     description: The schema to connect to the database server


### PR DESCRIPTION
This appears to have been left out (see docs https://airflow.apache.org/docs/apache-airflow-providers-microsoft-mssql/stable/connections/mssql.html), adding port as a required field in the standard payload.

Copying the port config from Postgres: https://github.com/astronomer/airflow-connection-docs/blob/52de190e4d5aadd32087f85914823ad60edba2e0/connections/dev/postgres/base.yml#L22