### PR TITLE
Pull GitHub access token from `password` field

### DIFF
--- a/connections/dev/github/base.yml
+++ b/connections/dev/github/base.yml
@@ -1,21 +1,21 @@
 id: github_base
 connection_type: github
 visible: true
-connection_name: Github
-description: Configure a Github connection
+connection_name: GitHub
+description: Configure a GitHub connection
 package: apache-airflow-providers-github
 parameters:
-  - airflow_param_name: access_token
+  - airflow_param_name: password
     friendly_name: Access Token
-    description: Personal Access token with required permissions.
+    description: Personal access token with required permissions.
     example: ghp_abcdefghijk1234567890
     type: str
     is_required: true
     is_secret: true
-    is_in_extra: true
+    is_in_extra: false
   - airflow_param_name: host
     friendly_name: Host
-    description: Specify the GitHub Enterprise Url that can be used for GitHub Enterprise connection.
+    description: Specify the GitHub Enterprise URL when connecting to a GitHub Enterprise account.
     example: https://github.mydomain.com
     type: str
     is_required: false


### PR DESCRIPTION
The access token in a GitHub connection comes from the base `password` parameter in a generic Airflow Connection rather than Extras.